### PR TITLE
Clients: add modify and clear

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -1,5 +1,9 @@
 name: Build Python SDK
 
+env:
+  BLYSS_STAGING_SERVER: https://dev2.api.blyss.dev
+  BLYSS_STAGING_API_KEY: Gh1pz1kEiNa1npEdDaRRvM1LsVypM1u2x1YbGb54
+
 on:
   push:
     branches: [ "main" ]
@@ -26,6 +30,14 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: Install Python SDK
+        working-directory: python
+        shell: bash
+        run: pip install .
+      - name: Test Python SDK
+        working-directory: python
+        shell: bash
+        run: python tests/test_service.py
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "editor.formatOnSave": true
 }

--- a/e2e-tests/api.ts
+++ b/e2e-tests/api.ts
@@ -1,0 +1,129 @@
+import type { Bucket, Client } from '@blyss/sdk';
+const blyss = require('@blyss/sdk/node');
+
+async function keyToValue(key: string, len: number): Promise<Uint8Array> {
+    const keyBytes = new TextEncoder().encode(key);
+    const value = new Uint8Array(len);
+    let i = 0;
+    // fill the value with the hash.
+    // if the hash is smaller than the value, we hash the hash again.
+    while (i < len) {
+        const hash = await crypto.subtle.digest('SHA-1', keyBytes);
+        const hashBytes = new Uint8Array(hash);
+        const toCopy = Math.min(hashBytes.length, len - i);
+        value.set(hashBytes.slice(0, toCopy), i);
+        i += toCopy;
+    }
+    return value;
+}
+
+async function verifyRead(key: string, value: Uint8Array): Promise<void> {
+    const expected = await keyToValue(key, value.length);
+    if (expected.toString() !== value.toString()) {
+        throw new Error('Incorrect value for key ' + key);
+    }
+}
+
+function generateKeys(n: number, seed: number = 0): string[] {
+    return new Array(n).fill(0).map(
+        (_, i) => seed.toString() + '-' + i.toString()
+    );
+}
+
+function generateBucketName(): string {
+    return 'api-tester-' + Math.random().toString(16).substring(2, 10);
+}
+
+async function testBlyssService(endpoint: string = 'https://dev2.api.blyss.dev') {
+    const apiKey = process.env.BLYSS_API_KEY;
+    if (!apiKey) {
+        throw new Error('BLYSS_API_KEY environment variable is not set');
+    }
+    console.log('Using key: ' + apiKey + ' to connect to ' + endpoint);
+    const client: Client = await new blyss.Client(
+        {
+            endpoint: endpoint,
+            apiKey: apiKey
+        }
+    );
+    // generate random string for bucket name
+    const bucketName = generateBucketName();
+    await client.create(bucketName);
+    const bucket: Bucket = await client.connect(bucketName);
+    console.log(bucket.metadata);
+
+    // generate N random keys
+    const N = 100;
+    const itemSize = 32;
+    let localKeys = generateKeys(N);
+    function getRandomKey(): string {
+        return localKeys[Math.floor(Math.random() * localKeys.length)];
+    }
+    // write all N keys
+    await bucket.write(
+        await Promise.all(localKeys.map(
+            async (k) => ({
+                k: await keyToValue(k, itemSize)
+            })
+        ))
+    );
+    console.log(`Wrote ${N} keys`);
+
+    // read a random key
+    let testKey = getRandomKey();
+    let value = await bucket.privateRead(testKey);
+    await verifyRead(testKey, value);
+    console.log(`Read key ${testKey}`);
+
+    // delete testKey from the bucket, and localData.
+    await bucket.deleteKey(testKey);
+    localKeys.splice(localKeys.indexOf(testKey), 1);
+    console.log(`Deleted key ${testKey}`);
+
+    // write a new value
+    testKey = 'newKey0';
+    await bucket.write({ testKey: keyToValue(testKey, itemSize) });
+    localKeys.push(testKey);
+    console.log(`Wrote key ${testKey}`);
+
+    // clear all keys
+    await bucket.clearEntireBucket();
+    localKeys = [];
+    console.log('Cleared bucket');
+
+    // write a new set of N keys
+    localKeys = generateKeys(N, 1);
+    await bucket.write(
+        await Promise.all(localKeys.map(
+            async (k) => ({
+                k: await keyToValue(k, itemSize)
+            })
+        ))
+    );
+    console.log(`Wrote ${N} keys`);
+
+    // rename the bucket
+    const newBucketName = bucketName + '-rn';
+    await bucket.rename(newBucketName);
+    console.log(`Renamed bucket`);
+    console.log(await bucket.info());
+
+    // random read
+    testKey = getRandomKey();
+    value = await bucket.privateRead(testKey);
+    await verifyRead(testKey, value);
+    console.log(`Read key ${testKey}`);
+
+    // destroy the bucket
+    await bucket.destroyEntireBucket();
+    console.log(`Destroyed bucket ${bucket.name}`);
+}
+
+async function main() {
+    const endpoint = "https://dev2.api.blyss.dev"
+    console.log('Testing Blyss service at URL ' + endpoint);
+    await testBlyssService(endpoint);
+    console.log('All tests completed successfully.');
+}
+
+main();

--- a/js/client/api.ts
+++ b/js/client/api.ts
@@ -4,6 +4,8 @@ import { gzip } from '../compression/pako';
 import { BloomFilter, bloomFilterFromBytes } from '../data/bloom';
 
 const CREATE_PATH = '/create';
+const MODIFY_PATH = '/modify';
+const CLEAR_PATH = '/clear';
 const DESTROY_PATH = '/destroy';
 const CHECK_PATH = '/check';
 const DELETE_PATH = '/delete';
@@ -216,6 +218,18 @@ class Api {
   }
 
   /**
+   * Modify a bucket's properties.
+   *
+   * @param bucketName The name of the bucket.
+   * @param dataJson A JSON-encoded string of the bucket metadata. Supports the same fields as `create()`.
+   * @returns Bucket metadata after update.
+   */
+  async modify(bucketName: string, dataJson: string): Promise<BucketMetadata> {
+    return await postData(this.apiKey, this.urlFor(bucketName, MODIFY_PATH), dataJson, true);
+  }
+
+
+  /**
    * Get the Bloom filter for keys in this bucket. The Bloom filter contains all
    * keys ever inserted into this bucket; it does not remove deleted keys.
    *
@@ -299,6 +313,16 @@ class Api {
     await postData(
       this.apiKey,
       this.urlFor(bucketName, DESTROY_PATH),
+      '',
+      false
+    );
+  }
+
+  /** Clear contents of this bucket. */
+  async clear(bucketName: string) {
+    await postData(
+      this.apiKey,
+      this.urlFor(bucketName, CLEAR_PATH),
       '',
       false
     );

--- a/js/index.ts
+++ b/js/index.ts
@@ -3,11 +3,10 @@ import type { KeyInfo } from './bucket/bucket';
 import type { ApiConfig } from './bucket/bucket_service';
 import { BucketService } from './bucket/bucket_service';
 import type { ApiError } from './client/api';
-import { DataWithMetadata } from './data/serializer';
 
 export { BucketService as Client, Bucket };
 
-export type { KeyInfo, BucketService, ApiError, ApiConfig, DataWithMetadata };
+export type { KeyInfo, BucketService, ApiError, ApiConfig };
 
 // External copyright notices:
 /*! pako (C) 1995-2013 Jean-loup Gailly and Mark Adler */

--- a/js/tests/serializer.test.ts
+++ b/js/tests/serializer.test.ts
@@ -23,7 +23,7 @@ describe('serialization/deserialization routines', () => {
     0,
     null
   ])(`should be inverses for: %s`, val => {
-    expect(deserialize(serialize(val)).data).toEqual(val);
+    expect(deserialize(serialize(val))).toEqual(val);
   });
 });
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "start": "webpack-dev-server --open",
     "test": "jest",
     "e2e-tests": "npm link && cd lib/server && cargo build --release && cd ../../e2e-tests && npm link @blyss/sdk && npx ts-node main.ts ../lib/server/target/release/server params",
+    "api-tests": "npm run --silent build && npm link && cd e2e-tests && npm link @blyss/sdk && npx ts-node api.ts",
     "lint": "eslint . --ext .ts"
   },
   "devDependencies": {

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "blyss-client-python"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "pyo3",
  "spiral-rs",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blyss-client-python"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/python/blyss/api.py
+++ b/python/blyss/api.py
@@ -18,7 +18,9 @@ from blyss.req_compression import get_session
 from blyss.bloom import BloomFilter
 
 CREATE_PATH = "/create"
+MODIFY_PATH = "/modify"
 DESTROY_PATH = "/destroy"
+CLEAR_PATH = "/clear"
 CHECK_PATH = "/check"
 LIST_BUCKETS_PATH = "/list-buckets"
 DELETE_PATH = "/delete"
@@ -208,6 +210,16 @@ class API:
     def _url_for(self, bucket_name: str, path: str) -> str:
         return self.service_endpoint + "/" + bucket_name + path
 
+    def modify(self, bucket_name: str, data_json: str) -> dict[Any, Any]:
+        """Modify existing bucket.
+         
+        Args:
+            data_json (str): same as create.
+        """
+        return _post_data_json(
+            self.api_key, self._url_for(bucket_name, MODIFY_PATH), data_json
+        )
+
     def meta(self, bucket_name: str) -> dict[Any, Any]:
         """Get metadata about a bucket.
 
@@ -257,6 +269,10 @@ class API:
     def destroy(self, bucket_name: str):
         """Destroy this bucket."""
         _post_data(self.api_key, self._url_for(bucket_name, DESTROY_PATH), "")
+
+    def clear(self, bucket_name: str):
+        """Delete all keys in this bucket."""
+        _post_data(self.api_key, self._url_for(bucket_name, CLEAR_PATH), "")
 
     def write(self, bucket_name: str, data: bytes):
         """Write some data to this bucket."""

--- a/python/blyss/blyss_lib.py
+++ b/python/blyss/blyss_lib.py
@@ -7,7 +7,7 @@ the compiled Rust code.
 """
 
 
-from typing import Any
+from typing import Any, Optional
 from . import blyss, seed  # type: ignore
 
 # NB:   There are many "type: ignore"s on purpose. Type information
@@ -82,7 +82,7 @@ class BlyssLib:
         """
         return bytes(blyss.decode_response(self.inner_client, response))  # type: ignore
 
-    def extract_result(self, key: str, data: bytes) -> bytes:
+    def extract_result(self, key: str, data: bytes) -> Optional[bytes]:
         """Extracts the value for a given key, given the plaintext data from a response.
 
         Args:
@@ -92,7 +92,11 @@ class BlyssLib:
         Returns:
             bytes: The plaintext data corresponding to the given key.
         """
-        return bytes(blyss.extract_result(self.inner_client, key, data))  # type: ignore
+        r = blyss.extract_result(self.inner_client, key, data)
+        if r is None:
+            return None
+        else:
+            return bytes(r)
 
     def __init__(self, params: str, secret_seed: str):
         """Initializes a new BlyssLib instance.

--- a/python/blyss/bucket.py
+++ b/python/blyss/bucket.py
@@ -118,7 +118,7 @@ class Bucket:
                     "content-type": "application/octet-stream",
                 }
                 row.append(fmt)
-                row_size += int(72 + len(key) + len(value_str))
+                row_size += int(24 + len(key) + len(value_str) + 48)
 
             # if the new row doesn't fit into the current chunk, start a new one
             if current_chunk_size + row_size > _MAX_PAYLOAD:
@@ -211,6 +211,14 @@ class Bucket:
     def list_keys(self) -> dict[str, Any]:
         """Gets info on all keys in this bucket."""
         return self.api.list_keys(self.name)
+    
+    def rename(self, new_name: str):
+        """Renames this bucket."""
+        bucket_create_req = {
+            "name": new_name,
+        }
+        self.api.modify(self.name, json.dumps(bucket_create_req))
+        self.name = new_name
 
     def write(self, kv_pairs: dict[str, Union[tuple[Any, Optional[Any]], Any]]):
         """Writes the supplied key-value pair(s) into the bucket.
@@ -250,6 +258,14 @@ class Bucket:
     def destroy_entire_bucket(self):
         """Destroys the entire bucket. This action is permanent and irreversible."""
         self.api.destroy(self.name)
+
+    def clear_entire_bucket(self):
+        """Deletes all keys in this bucket. This action is permanent and irreversible.
+        
+        Differs from destroy in that the bucket's metadata 
+        (e.g. permissions, PIR scheme parameters, and clients' setup data) are preserved.
+        """
+        self.api.clear(self.name)
 
     def private_read(self, keys: Union[str, list[str]]) -> Union[bytes, list[bytes]]:
         """Privately reads the supplied key from the bucket,

--- a/python/blyss/bucket_service.py
+++ b/python/blyss/bucket_service.py
@@ -3,7 +3,7 @@ from . import bucket, api, seed
 import json
 
 BLYSS_BUCKET_URL = "https://beta.api.blyss.dev"
-DEFAULT_BUCKET_PARAMETERS = {"maxItemSize": 1000}
+DEFAULT_BUCKET_PARAMETERS = {"maxItemSize": 1000, "keyStoragePolicy": "bloom"}
 
 ApiConfig = dict[str, str]
 

--- a/python/tests/test_service.py
+++ b/python/tests/test_service.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import random
 import hashlib
 import traceback
@@ -32,11 +33,8 @@ def generateBucketName() -> str:
     return f"api-tester-{tag:#0{6}x}"
 
 
-async def main(endpoint: str):
-    api_key = os.environ.get("BLYSS_API_KEY", None)
-    if not api_key:
-        raise Exception("BLYSS_API_KEY environment variable is not set")
-    print("Using key: " + api_key + " to connect to " + endpoint)
+async def main(endpoint: str, api_key: str):
+    print("Testing Blyss server at " + endpoint)
     client = blyss.Client({"endpoint": endpoint, "api_key": api_key})
     # generate random string for bucket name
     bucketName = generateBucketName()
@@ -101,4 +99,16 @@ async def main(endpoint: str):
 if __name__ == "__main__":
     import asyncio
 
-    asyncio.run(main("https://dev2.api.blyss.dev"))
+    api_key = os.environ.get("BLYSS_STAGING_API_KEY", None)
+    endpoint = os.environ.get("BLYSS_STAGING_SERVER", None)
+    if len(sys.argv) > 1:
+        print("Using endpoint from command line")
+        endpoint = sys.argv[1]
+    if len(sys.argv) > 2:
+        print("Using api_key from command line")
+        api_key = sys.argv[2]
+    print("DEBUG", api_key, endpoint)
+    assert endpoint is not None
+    assert api_key is not None
+
+    asyncio.run(main(endpoint, api_key))

--- a/python/tests/test_service.py
+++ b/python/tests/test_service.py
@@ -1,0 +1,104 @@
+import os
+import random
+import hashlib
+import traceback
+import blyss
+
+
+def key_to_gold_value(key: str, length: int = 512) -> bytes:
+    h = hashlib.md5()
+    h.update(key.encode("utf-8"))
+    value = h.digest()
+    while len(value) < length:
+        h.update(b"0")
+        value += h.digest()
+    return value[:length]
+
+
+def verify_read(key: str, value: bytes):
+    try:
+        assert value == key_to_gold_value(key, len(value))
+    except:
+        print(traceback.format_exc())
+        raise
+
+
+def generate_keys(n: int, seed: int = 0) -> list:
+    return [f"{seed}-{i}" for i in range(n)]
+
+
+def generateBucketName() -> str:
+    tag = int(random.random() * 1e6)
+    return f"api-tester-{tag:#0{6}x}"
+
+
+async def main(endpoint: str):
+    api_key = os.environ.get("BLYSS_API_KEY", None)
+    if not api_key:
+        raise Exception("BLYSS_API_KEY environment variable is not set")
+    print("Using key: " + api_key + " to connect to " + endpoint)
+    client = blyss.Client({"endpoint": endpoint, "api_key": api_key})
+    # generate random string for bucket name
+    bucketName = generateBucketName()
+    client.create(bucketName)
+    bucket = client.connect_async(bucketName)
+    print(bucket.info())
+
+    # generate N random keys
+    N = 20000
+    itemSize = 32
+    localKeys = generate_keys(N, 0)
+    # write all N keys
+    await bucket.write({k: key_to_gold_value(k, itemSize) for k in localKeys})
+    print(f"Wrote {N} keys")
+
+    # read a random key
+    testKey = random.choice(localKeys)
+    value = await bucket.private_read([testKey])
+    verify_read(testKey, value[0])
+    print(f"Read key {testKey}")
+
+    # delete testKey from the bucket, and localData.
+    bucket.delete_key(testKey)
+    localKeys.remove(testKey)
+    value = await bucket.private_read([testKey])
+    # TODO: why aren't deletes reflected in the next read?
+    # assert value is None
+    print(f"Deleted key {testKey}")
+
+    # clear all keys
+    bucket.clear_entire_bucket()
+    localKeys = []
+    print("Cleared bucket")
+
+    # write a new set of N keys
+    localKeys = generate_keys(N, 2)
+    await bucket.write({k: key_to_gold_value(k, itemSize) for k in localKeys})
+    print(f"Wrote {N} keys")
+
+    # test if clear took AFTER the new write
+    value = await bucket.private_read([testKey])
+    if value is not None:
+        print(f"ERROR: {testKey} was not deleted or cleared!")
+
+    # rename the bucket
+    newBucketName = bucketName + "-rn"
+    bucket.rename(newBucketName)
+    print("Renamed bucket")
+    print(bucket.info())
+
+    # read a random key
+    testKey = random.choice(localKeys)
+    value = await bucket.private_read([testKey])
+    verify_read(testKey, value[0])
+    print(f"Read key {testKey}")
+
+    # destroy the bucket
+    bucket.destroy_entire_bucket()
+    print("Destroyed bucket")
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main("https://dev2.api.blyss.dev"))


### PR DESCRIPTION
Adds support for two new client functions: clearEntireBucket() and rename().
Add integration tests for the Blyss managed service, in both JS and Python.
Removes "metadata" concept from client APIs.
Bump python SDK version to 0.1.8.